### PR TITLE
Unique Namer Fix: bug on extension detection

### DIFF
--- a/src/Naming/UniqueNamer.php
+++ b/src/Naming/UniqueNamer.php
@@ -17,7 +17,7 @@ class UniqueNamer extends \Atom\Uploader\Naming\UniqueNamer
     {
         $name = parent::name($file);
 
-        if ($file instanceof UploadedFile && empty($file->getExtension())) {
+        if ($file instanceof UploadedFile && !empty($file->getExtension())) {
             $name .= '.' . $this->escape($file->getClientOriginalExtension());
         }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -19,7 +19,8 @@
             <argument type="service" id="atom_uploader.dispatcher"/>
         </service>
 
-        <service id="atom_uploader.filesystem_adapter_repo" class="Atom\Uploader\Filesystem\FilesystemAdapterRepo">
+        <service id="atom_uploader.filesystem_adapter_repo" class="Atom\Uploader\Filesystem\FilesystemAdapterRepo"
+                 public="true">
             <argument type="collection"/> <!-- will be contained with filesystem adapters. -->
         </service>
 


### PR DESCRIPTION
DI config fix: `filesystem_adapter_repo` removed when DIC optimization.
Error (Symfony 4.3):
```
The "atom_uploader.filesystem_adapter_repo" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.
```
---
Also UniqueNamer Fix: bug of extension detection